### PR TITLE
feat: add debug output and CLI detect command

### DIFF
--- a/bin/coverage-runner.ts
+++ b/bin/coverage-runner.ts
@@ -3,6 +3,8 @@
 import { Command } from 'commander';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { setDebugMode } from '../src/utils/logger';
+import { detectRunners } from '../src/utils/detectRunners';
 
 function getVersion(): string {
   try {
@@ -21,7 +23,27 @@ function createCLI(): Command {
   program
     .name('coverage-runner')
     .description('A tool for running and managing code coverage analysis')
-    .version(getVersion());
+    .version(getVersion())
+    .option('-d, --debug', 'enable debug output');
+
+  // Add detect command
+  program
+    .command('detect')
+    .description('Detect test runners in the current project')
+    .option('-p, --path <path>', 'path to package.json file')
+    .action((options: { path?: string }) => {
+      if (program.opts().debug) {
+        setDebugMode(true);
+      }
+
+      const runners = detectRunners(options.path);
+
+      if (runners.length > 0) {
+        console.log(`Detected test runners: ${runners.join(', ')}`);
+      } else {
+        console.log('No test runners detected');
+      }
+    });
 
   // Future subcommands will be added here
   // Example structure for extensibility:

--- a/src/utils/detectRunners.ts
+++ b/src/utils/detectRunners.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { logger } from './logger';
 
 export type TestRunner = 'jest' | 'vitest' | 'mocha' | 'ava';
 
@@ -36,25 +37,47 @@ const RUNNER_DETECTION_MAP: Record<TestRunner, RunnerDetectionConfig> = {
 function checkDependencies(
   allDependencies: Record<string, string>,
   dependencyNames: string[]
-): boolean {
-  return dependencyNames.some(name => name in allDependencies);
+): { found: boolean; matchedDeps: string[] } {
+  const matchedDeps = dependencyNames.filter(name => name in allDependencies);
+  return {
+    found: matchedDeps.length > 0,
+    matchedDeps,
+  };
 }
 
 function checkScripts(
   scripts: Record<string, string>,
   scriptKeywords: string[]
-): boolean {
-  const allScripts = Object.values(scripts).join(' ').toLowerCase();
-  return scriptKeywords.some(keyword =>
-    allScripts.includes(keyword.toLowerCase())
-  );
+): {
+  found: boolean;
+  matchedScripts: Array<{ name: string; content: string }>;
+} {
+  const matchedScripts: Array<{ name: string; content: string }> = [];
+
+  for (const [scriptName, scriptContent] of Object.entries(scripts)) {
+    const hasKeyword = scriptKeywords.some(keyword =>
+      scriptContent.toLowerCase().includes(keyword.toLowerCase())
+    );
+
+    if (hasKeyword) {
+      matchedScripts.push({ name: scriptName, content: scriptContent });
+    }
+  }
+
+  return {
+    found: matchedScripts.length > 0,
+    matchedScripts,
+  };
 }
 
 export function detectRunners(packageJsonPath?: string): TestRunner[] {
   const resolvedPath =
     packageJsonPath ?? path.join(process.cwd(), 'package.json');
 
+  logger.debug(`Detecting test runners from: ${resolvedPath}`);
+
   if (!fs.existsSync(resolvedPath)) {
+    logger.debug(`Package.json not found at: ${resolvedPath}`);
     return [];
   }
 
@@ -68,22 +91,70 @@ export function detectRunners(packageJsonPath?: string): TestRunner[] {
 
     const allDependencies = { ...dependencies, ...devDependencies };
 
+    logger.debug('Package.json contents:');
+    logger.debug('- Dependencies:', Object.keys(dependencies));
+    logger.debug('- DevDependencies:', Object.keys(devDependencies));
+    logger.debug('- Scripts:', Object.keys(scripts));
+
     const detectedRunners: TestRunner[] = [];
+    const detectionDetails: Array<{
+      runner: TestRunner;
+      foundVia: string[];
+      matchedDeps: string[];
+      matchedScripts: Array<{ name: string; content: string }>;
+    }> = [];
 
     for (const [runner, config] of Object.entries(RUNNER_DETECTION_MAP)) {
-      const hasDependency = checkDependencies(
+      const depCheck = checkDependencies(
         allDependencies,
         config.dependencyNames
       );
-      const hasScript = checkScripts(scripts, config.scriptKeywords);
+      const scriptCheck = checkScripts(scripts, config.scriptKeywords);
 
-      if (hasDependency || hasScript) {
+      const foundVia: string[] = [];
+      if (depCheck.found) foundVia.push('dependencies');
+      if (scriptCheck.found) foundVia.push('scripts');
+
+      if (depCheck.found || scriptCheck.found) {
         detectedRunners.push(runner as TestRunner);
+        detectionDetails.push({
+          runner: runner as TestRunner,
+          foundVia,
+          matchedDeps: depCheck.matchedDeps,
+          matchedScripts: scriptCheck.matchedScripts,
+        });
+      }
+    }
+
+    logger.debug(`\nDetection Results:`);
+    logger.debug(
+      `Found ${detectedRunners.length} test runner(s): [${detectedRunners.join(', ')}]`
+    );
+
+    if (detectionDetails.length > 0) {
+      logger.debug('\nDetailed Detection Information:');
+      for (const detail of detectionDetails) {
+        logger.debug(`\n${detail.runner.toUpperCase()}:`);
+        logger.debug(`  Found via: ${detail.foundVia.join(', ')}`);
+
+        if (detail.matchedDeps.length > 0) {
+          logger.debug(
+            `  Matched dependencies: ${detail.matchedDeps.join(', ')}`
+          );
+        }
+
+        if (detail.matchedScripts.length > 0) {
+          logger.debug(`  Matched scripts:`);
+          for (const script of detail.matchedScripts) {
+            logger.debug(`    - ${script.name}: "${script.content}"`);
+          }
+        }
       }
     }
 
     return detectedRunners;
-  } catch {
+  } catch (error) {
+    logger.debug(`Error parsing package.json: ${String(error)}`);
     return [];
   }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,88 @@
+export enum LogLevel {
+  ERROR = 0,
+  WARN = 1,
+  INFO = 2,
+  DEBUG = 3,
+}
+
+interface LoggerConfig {
+  level: LogLevel;
+  enabled: boolean;
+}
+
+class Logger {
+  private config: LoggerConfig;
+
+  constructor() {
+    this.config = {
+      level: this.getLogLevelFromEnv(),
+      enabled: true,
+    };
+  }
+
+  private getLogLevelFromEnv(): LogLevel {
+    const envLevel = process.env.LOG_LEVEL?.toUpperCase();
+    switch (envLevel) {
+      case 'ERROR':
+        return LogLevel.ERROR;
+      case 'WARN':
+        return LogLevel.WARN;
+      case 'INFO':
+        return LogLevel.INFO;
+      case 'DEBUG':
+        return LogLevel.DEBUG;
+      default:
+        return LogLevel.INFO;
+    }
+  }
+
+  setLevel(level: LogLevel): void {
+    this.config.level = level;
+  }
+
+  setDebugMode(enabled: boolean): void {
+    if (enabled) {
+      this.config.level = LogLevel.DEBUG;
+    }
+    this.config.enabled = enabled;
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    return this.config.enabled && level <= this.config.level;
+  }
+
+  private formatMessage(level: string, message: string): string {
+    const timestamp = new Date().toISOString();
+    return `[${timestamp}] [${level}] ${message}`;
+  }
+
+  error(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.ERROR)) {
+      console.error(this.formatMessage('ERROR', message), ...args);
+    }
+  }
+
+  warn(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.WARN)) {
+      console.warn(this.formatMessage('WARN', message), ...args);
+    }
+  }
+
+  info(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.INFO)) {
+      console.info(this.formatMessage('INFO', message), ...args);
+    }
+  }
+
+  debug(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.DEBUG)) {
+      console.debug(this.formatMessage('DEBUG', message), ...args);
+    }
+  }
+}
+
+export const logger = new Logger();
+
+export function setDebugMode(enabled: boolean): void {
+  logger.setDebugMode(enabled);
+}


### PR DESCRIPTION
## Summary
- Add comprehensive logger utility with configurable log levels and environment variable support
- Implement detailed debug output for detectRunners function with extensive diagnostic information
- Add CLI detect command with --debug and --path options for enhanced usability

## Key Features
- **Logger Utility**: Configurable via `LOG_LEVEL` environment variable or programmatic `setDebugMode()`
- **Detailed Debug Output**: Shows detection source, package.json contents, and matched dependencies/scripts
- **CLI Integration**: `detect` command with `--debug` global option and `--path` for custom package.json location
- **Enhanced Detection**: Returns detailed information about what triggered each test runner detection

## Debug Output Example
```
[2025-07-02T04:05:53.417Z] [DEBUG] Detecting test runners from: /path/to/package.json
[2025-07-02T04:05:53.418Z] [DEBUG] Package.json contents:
[2025-07-02T04:05:53.419Z] [DEBUG] - Dependencies: [ 'commander' ]
[2025-07-02T04:05:53.419Z] [DEBUG] - DevDependencies: ['vitest', '@types/node', ...]
[2025-07-02T04:05:53.421Z] [DEBUG] Found 1 test runner(s): [vitest]
[2025-07-02T04:05:53.422Z] [DEBUG] VITEST:
[2025-07-02T04:05:53.423Z] [DEBUG]   Found via: dependencies, scripts
[2025-07-02T04:05:53.423Z] [DEBUG]   Matched dependencies: vitest
[2025-07-02T04:05:53.424Z] [DEBUG]   Matched scripts:
[2025-07-02T04:05:53.424Z] [DEBUG]     - test: "vitest run"
```

## Test plan
- [x] CLI commands working: `coverage-runner detect --debug`
- [x] TypeScript compilation passes
- [x] ESLint passes with no errors
- [x] Logger utility supports multiple log levels
- [x] Debug output shows comprehensive detection information

🤖 Generated with [Claude Code](https://claude.ai/code)