### PR TITLE
feat: implement coverage runners with comprehensive TDD approach

### DIFF
--- a/examples/jest-project/package.json
+++ b/examples/jest-project/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "jest-sample",
+  "version": "1.0.0",
+  "description": "Sample project for testing Jest coverage",
+  "scripts": {
+    "test": "jest",
+    "test:coverage": "jest --coverage"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "@types/jest": "^29.0.0"
+  }
+}

--- a/examples/jest-project/src/calculator.js
+++ b/examples/jest-project/src/calculator.js
@@ -1,0 +1,25 @@
+function add(a, b) {
+  return a + b;
+}
+
+function subtract(a, b) {
+  return a - b;
+}
+
+function multiply(a, b) {
+  return a * b;
+}
+
+function divide(a, b) {
+  if (b === 0) {
+    throw new Error('Division by zero');
+  }
+  return a / b;
+}
+
+module.exports = {
+  add,
+  subtract,
+  multiply,
+  divide,
+};

--- a/examples/jest-project/src/calculator.test.js
+++ b/examples/jest-project/src/calculator.test.js
@@ -1,0 +1,35 @@
+const { add, subtract, multiply, divide } = require('./calculator');
+
+describe('Calculator', () => {
+  describe('add', () => {
+    it('should add two positive numbers', () => {
+      expect(add(2, 3)).toBe(5);
+    });
+
+    it('should add negative numbers', () => {
+      expect(add(-1, -2)).toBe(-3);
+    });
+  });
+
+  describe('subtract', () => {
+    it('should subtract two numbers', () => {
+      expect(subtract(5, 3)).toBe(2);
+    });
+  });
+
+  describe('multiply', () => {
+    it('should multiply two numbers', () => {
+      expect(multiply(3, 4)).toBe(12);
+    });
+  });
+
+  describe('divide', () => {
+    it('should divide two numbers', () => {
+      expect(divide(10, 2)).toBe(5);
+    });
+
+    it('should throw error when dividing by zero', () => {
+      expect(() => divide(10, 0)).toThrow('Division by zero');
+    });
+  });
+});

--- a/examples/vitest-project/package.json
+++ b/examples/vitest-project/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vitest-sample",
+  "version": "1.0.0",
+  "description": "Sample project for testing Vitest coverage",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0",
+    "@vitest/coverage-v8": "^1.0.0"
+  }
+}

--- a/examples/vitest-project/src/math.js
+++ b/examples/vitest-project/src/math.js
@@ -1,0 +1,21 @@
+export function square(x) {
+  return x * x;
+}
+
+export function cube(x) {
+  return x * x * x;
+}
+
+export function isEven(n) {
+  return n % 2 === 0;
+}
+
+export function factorial(n) {
+  if (n < 0) {
+    throw new Error('Factorial of negative number is not defined');
+  }
+  if (n === 0 || n === 1) {
+    return 1;
+  }
+  return n * factorial(n - 1);
+}

--- a/examples/vitest-project/src/math.test.js
+++ b/examples/vitest-project/src/math.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { square, cube, isEven, factorial } from './math.js';
+
+describe('Math Functions', () => {
+  describe('square', () => {
+    it('should return the square of a number', () => {
+      expect(square(4)).toBe(16);
+      expect(square(-3)).toBe(9);
+      expect(square(0)).toBe(0);
+    });
+  });
+
+  describe('cube', () => {
+    it('should return the cube of a number', () => {
+      expect(cube(3)).toBe(27);
+      expect(cube(-2)).toBe(-8);
+      expect(cube(0)).toBe(0);
+    });
+  });
+
+  describe('isEven', () => {
+    it('should return true for even numbers', () => {
+      expect(isEven(2)).toBe(true);
+      expect(isEven(0)).toBe(true);
+      expect(isEven(-4)).toBe(true);
+    });
+
+    it('should return false for odd numbers', () => {
+      expect(isEven(1)).toBe(false);
+      expect(isEven(3)).toBe(false);
+      expect(isEven(-1)).toBe(false);
+    });
+  });
+
+  describe('factorial', () => {
+    it('should calculate factorial correctly', () => {
+      expect(factorial(0)).toBe(1);
+      expect(factorial(1)).toBe(1);
+      expect(factorial(5)).toBe(120);
+    });
+
+    it('should throw error for negative numbers', () => {
+      expect(() => factorial(-1)).toThrow('Factorial of negative number is not defined');
+    });
+  });
+});

--- a/examples/vitest-project/vitest.config.js
+++ b/examples/vitest-project/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      reporter: ['text', 'html', 'lcov'],
+      reportsDirectory: './coverage',
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "commander": "^14.0.0"
+        "commander": "^14.0.0",
+        "execa": "^9.6.0"
       },
       "bin": {
         "coverage-runner": "dist/bin/coverage-runner.js"
@@ -1039,6 +1040,24 @@
         "win32"
       ]
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -1884,7 +1903,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2258,6 +2276,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/execa": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
+      "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
@@ -2322,6 +2366,21 @@
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2415,6 +2474,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
@@ -2469,6 +2544,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/husky": {
@@ -2590,11 +2674,46 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/js-tokens": {
@@ -2992,6 +3111,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -3071,6 +3218,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3085,7 +3244,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3194,6 +3352,21 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
+      "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pstree.remy": {
@@ -3383,7 +3556,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3396,7 +3568,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3413,7 +3584,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -3546,6 +3716,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3827,6 +4009,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4060,7 +4254,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4161,6 +4354,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
+      "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "commander": "^14.0.0"
+    "commander": "^14.0.0",
+    "execa": "^9.6.0"
   }
 }

--- a/src/runners/DummyRunner.ts
+++ b/src/runners/DummyRunner.ts
@@ -1,0 +1,19 @@
+import { BaseRunner, CoverageResult } from './Runner';
+
+export class DummyRunner extends BaseRunner {
+  constructor() {
+    super('./coverage');
+  }
+
+  async runCoverage(): Promise<CoverageResult> {
+    const startTime = Date.now();
+    
+    // Simulate minimal processing time
+    await new Promise(resolve => setTimeout(resolve, 1));
+    
+    const endTime = Date.now();
+    const duration = endTime - startTime;
+
+    return this.createSuccessResult(this.outputDir, duration);
+  }
+}

--- a/src/runners/JestRunner.ts
+++ b/src/runners/JestRunner.ts
@@ -1,0 +1,45 @@
+import { execa } from 'execa';
+import { BaseRunner, CoverageResult } from './Runner';
+import { logger } from '../utils/logger';
+
+export class JestRunner extends BaseRunner {
+  constructor() {
+    super('./coverage');
+  }
+
+  async runCoverage(): Promise<CoverageResult> {
+    const startTime = Date.now();
+    
+    logger.debug('Running Jest coverage...');
+    
+    try {
+      const args = ['--coverage', '--coverageDirectory', this.outputDir];
+      
+      logger.debug(`Executing: jest ${args.join(' ')}`);
+      
+      const result = await execa('npx', ['jest', ...args], {
+        stdio: 'pipe',
+      });
+      
+      const endTime = Date.now();
+      const duration = endTime - startTime;
+      
+      logger.debug(`Jest completed successfully in ${duration}ms`);
+      
+      return this.createSuccessResult(this.outputDir, duration);
+    } catch (error: any) {
+      const endTime = Date.now();
+      const duration = endTime - startTime;
+      
+      logger.debug(`Jest failed after ${duration}ms:`, error);
+      
+      return this.createFailureResult(
+        this.outputDir,
+        error.exitCode || 1,
+        error.stderr,
+        error.stdout,
+        duration
+      );
+    }
+  }
+}

--- a/src/runners/Runner.ts
+++ b/src/runners/Runner.ts
@@ -1,0 +1,58 @@
+export interface CoverageResult {
+  success: boolean;
+  outputPath: string;
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+  duration?: number;
+}
+
+export interface Runner {
+  runCoverage(): Promise<CoverageResult>;
+}
+
+export abstract class BaseRunner implements Runner {
+  protected outputDir: string;
+
+  constructor(outputDir: string = './coverage') {
+    this.outputDir = process.env.COVERAGE_OUTPUT_DIR || outputDir;
+  }
+
+  abstract runCoverage(): Promise<CoverageResult>;
+
+  protected createSuccessResult(outputPath: string, duration?: number): CoverageResult {
+    const result: CoverageResult = {
+      success: true,
+      outputPath,
+      exitCode: 0,
+    };
+    if (duration !== undefined) {
+      result.duration = duration;
+    }
+    return result;
+  }
+
+  protected createFailureResult(
+    outputPath: string,
+    exitCode: number,
+    stderr?: string,
+    stdout?: string,
+    duration?: number
+  ): CoverageResult {
+    const result: CoverageResult = {
+      success: false,
+      outputPath,
+      exitCode,
+    };
+    if (stderr !== undefined) {
+      result.stderr = stderr;
+    }
+    if (stdout !== undefined) {
+      result.stdout = stdout;
+    }
+    if (duration !== undefined) {
+      result.duration = duration;
+    }
+    return result;
+  }
+}

--- a/src/runners/RunnerFactory.ts
+++ b/src/runners/RunnerFactory.ts
@@ -1,0 +1,28 @@
+import { TestRunner } from '../utils/detectRunners';
+import { Runner } from './Runner';
+import { JestRunner } from './JestRunner';
+import { VitestRunner } from './VitestRunner';
+import { DummyRunner } from './DummyRunner';
+
+export class RunnerFactory {
+  static createRunner(runnerType: TestRunner): Runner {
+    switch (runnerType) {
+      case 'jest':
+        return new JestRunner();
+      case 'vitest':
+        return new VitestRunner();
+      case 'mocha':
+        // TODO: Implement MochaRunner
+        throw new Error('Mocha runner not yet implemented');
+      case 'ava':
+        // TODO: Implement AvaRunner
+        throw new Error('Ava runner not yet implemented');
+      default:
+        throw new Error(`Unknown runner type: ${runnerType}`);
+    }
+  }
+
+  static createDummyRunner(): Runner {
+    return new DummyRunner();
+  }
+}

--- a/src/runners/VitestRunner.ts
+++ b/src/runners/VitestRunner.ts
@@ -1,0 +1,45 @@
+import { execa } from 'execa';
+import { BaseRunner, CoverageResult } from './Runner';
+import { logger } from '../utils/logger';
+
+export class VitestRunner extends BaseRunner {
+  constructor() {
+    super('./coverage');
+  }
+
+  async runCoverage(): Promise<CoverageResult> {
+    const startTime = Date.now();
+    
+    logger.debug('Running Vitest coverage...');
+    
+    try {
+      const args = ['run', '--coverage', '--coverage.reportsDirectory', this.outputDir];
+      
+      logger.debug(`Executing: vitest ${args.join(' ')}`);
+      
+      const result = await execa('npx', ['vitest', ...args], {
+        stdio: 'pipe',
+      });
+      
+      const endTime = Date.now();
+      const duration = endTime - startTime;
+      
+      logger.debug(`Vitest completed successfully in ${duration}ms`);
+      
+      return this.createSuccessResult(this.outputDir, duration);
+    } catch (error: any) {
+      const endTime = Date.now();
+      const duration = endTime - startTime;
+      
+      logger.debug(`Vitest failed after ${duration}ms:`, error);
+      
+      return this.createFailureResult(
+        this.outputDir,
+        error.exitCode || 1,
+        error.stderr,
+        error.stdout,
+        duration
+      );
+    }
+  }
+}

--- a/test/e2e/cli-e2e.test.ts
+++ b/test/e2e/cli-e2e.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execa } from 'execa';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const CLI_PATH = path.join(__dirname, '../../dist/bin/coverage-runner.js');
+const JEST_EXAMPLE_PATH = path.join(__dirname, '../../examples/jest-project');
+const VITEST_EXAMPLE_PATH = path.join(__dirname, '../../examples/vitest-project');
+
+describe('CLI E2E Tests', () => {
+  beforeEach(() => {
+    // Clean up any existing coverage directories
+    const jestCoverageDir = path.join(JEST_EXAMPLE_PATH, 'coverage');
+    const vitestCoverageDir = path.join(VITEST_EXAMPLE_PATH, 'coverage');
+    
+    if (fs.existsSync(jestCoverageDir)) {
+      fs.rmSync(jestCoverageDir, { recursive: true, force: true });
+    }
+    if (fs.existsSync(vitestCoverageDir)) {
+      fs.rmSync(vitestCoverageDir, { recursive: true, force: true });
+    }
+  });
+
+  afterEach(() => {
+    // Clean up coverage directories after tests
+    const jestCoverageDir = path.join(JEST_EXAMPLE_PATH, 'coverage');
+    const vitestCoverageDir = path.join(VITEST_EXAMPLE_PATH, 'coverage');
+    
+    if (fs.existsSync(jestCoverageDir)) {
+      fs.rmSync(jestCoverageDir, { recursive: true, force: true });
+    }
+    if (fs.existsSync(vitestCoverageDir)) {
+      fs.rmSync(vitestCoverageDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should detect Jest in sample project', async () => {
+    const result = await execa('node', [CLI_PATH, 'detect', '--path', path.join(JEST_EXAMPLE_PATH, 'package.json')], {
+      stdio: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('jest');
+  }, 10000);
+
+  it('should detect Vitest in sample project', async () => {
+    const result = await execa('node', [CLI_PATH, 'detect', '--path', path.join(VITEST_EXAMPLE_PATH, 'package.json')], {
+      stdio: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('vitest');
+  }, 10000);
+
+  it('should run Jest coverage and create coverage directory', async () => {
+    const packageJsonPath = path.join(JEST_EXAMPLE_PATH, 'package.json');
+    const coverageDir = path.join(JEST_EXAMPLE_PATH, 'coverage');
+
+    // Set working directory and run coverage
+    const result = await execa('node', [CLI_PATH, 'run', '--path', packageJsonPath], {
+      cwd: JEST_EXAMPLE_PATH,
+      stdio: 'pipe',
+      timeout: 30000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('jest');
+    expect(result.stdout).toContain('Coverage analysis completed');
+
+    // Check if coverage directory was created
+    expect(fs.existsSync(coverageDir)).toBe(true);
+    
+    // Check for common coverage files
+    const coverageFiles = fs.readdirSync(coverageDir);
+    expect(coverageFiles.length).toBeGreaterThan(0);
+  }, 30000);
+
+  it('should attempt to run Vitest coverage (may fail due to missing dependencies)', async () => {
+    const packageJsonPath = path.join(VITEST_EXAMPLE_PATH, 'package.json');
+
+    // Run coverage command - it may fail due to missing dependencies in CI
+    const result = await execa('node', [CLI_PATH, 'run', '--path', packageJsonPath], {
+      cwd: VITEST_EXAMPLE_PATH,
+      stdio: 'pipe',
+      timeout: 30000,
+      reject: false, // Don't reject on non-zero exit code
+    });
+
+    // Should detect vitest and attempt to run it
+    expect(result.stdout).toContain('vitest');
+    expect(result.stdout).toContain('Coverage analysis completed');
+  }, 30000);
+
+  it('should handle projects with no test runners gracefully', async () => {
+    // Create a temporary package.json without test runners
+    const tempDir = path.join(__dirname, '../../temp-test');
+    const tempPackageJson = path.join(tempDir, 'package.json');
+    
+    fs.mkdirSync(tempDir, { recursive: true });
+    fs.writeFileSync(tempPackageJson, JSON.stringify({
+      name: 'no-runners',
+      version: '1.0.0',
+      dependencies: {
+        lodash: '^4.17.21'
+      }
+    }, null, 2));
+
+    try {
+      const result = await execa('node', [CLI_PATH, 'run', '--path', tempPackageJson], {
+        stdio: 'pipe',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('No test runners detected');
+    } finally {
+      // Clean up
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }, 10000);
+});

--- a/test/integration/cli-integration.test.ts
+++ b/test/integration/cli-integration.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { detectRunners } from '../../src/utils/detectRunners';
+import { RunnerFactory } from '../../src/runners/RunnerFactory';
+import { JestRunner } from '../../src/runners/JestRunner';
+import { VitestRunner } from '../../src/runners/VitestRunner';
+
+vi.mock('../../src/utils/detectRunners');
+vi.mock('../../src/runners/JestRunner');
+vi.mock('../../src/runners/VitestRunner');
+
+const mockDetectRunners = vi.mocked(detectRunners);
+const MockJestRunner = vi.mocked(JestRunner);
+const MockVitestRunner = vi.mocked(VitestRunner);
+
+describe('CLI Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should detect runners and execute them in sequence', async () => {
+    // Setup mocks
+    mockDetectRunners.mockReturnValue(['jest', 'vitest']);
+    
+    const mockJestInstance = {
+      runCoverage: vi.fn().mockResolvedValue({
+        success: true,
+        outputPath: './coverage',
+        duration: 1000,
+      }),
+    };
+    
+    const mockVitestInstance = {
+      runCoverage: vi.fn().mockResolvedValue({
+        success: true,
+        outputPath: './coverage',
+        duration: 500,
+      }),
+    };
+    
+    MockJestRunner.mockImplementation(() => mockJestInstance as any);
+    MockVitestRunner.mockImplementation(() => mockVitestInstance as any);
+
+    // Simulate CLI execution flow
+    const detectedRunners = detectRunners();
+    expect(detectedRunners).toEqual(['jest', 'vitest']);
+
+    // Execute each runner
+    const results = [];
+    for (const runnerType of detectedRunners) {
+      const runner = RunnerFactory.createRunner(runnerType);
+      const result = await runner.runCoverage();
+      results.push(result);
+    }
+
+    // Verify execution order and results
+    expect(mockJestInstance.runCoverage).toHaveBeenCalledTimes(1);
+    expect(mockVitestInstance.runCoverage).toHaveBeenCalledTimes(1);
+    expect(results).toHaveLength(2);
+    expect(results[0]?.success).toBe(true);
+    expect(results[1]?.success).toBe(true);
+  });
+
+  it('should handle runner failure gracefully', async () => {
+    mockDetectRunners.mockReturnValue(['jest']);
+    
+    const mockJestInstance = {
+      runCoverage: vi.fn().mockResolvedValue({
+        success: false,
+        outputPath: './coverage',
+        exitCode: 1,
+        stderr: 'Test failed',
+        duration: 1000,
+      }),
+    };
+    
+    MockJestRunner.mockImplementation(() => mockJestInstance as any);
+
+    const detectedRunners = detectRunners();
+    const firstRunner = detectedRunners[0];
+    if (!firstRunner) {
+      throw new Error('No runners detected');
+    }
+    const runner = RunnerFactory.createRunner(firstRunner);
+    const result = await runner.runCoverage();
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('Test failed');
+  });
+
+  it('should handle case when no runners are detected', () => {
+    mockDetectRunners.mockReturnValue([]);
+    
+    const detectedRunners = detectRunners();
+    expect(detectedRunners).toEqual([]);
+  });
+});

--- a/test/runners/DummyRunner.test.ts
+++ b/test/runners/DummyRunner.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { DummyRunner } from '../../src/runners/DummyRunner';
+
+describe('DummyRunner', () => {
+  it('should implement Runner interface', () => {
+    const runner = new DummyRunner();
+    expect(runner).toHaveProperty('runCoverage');
+    expect(typeof runner.runCoverage).toBe('function');
+  });
+
+  it('should return a resolved Promise when runCoverage() is called', async () => {
+    const runner = new DummyRunner();
+    const result = runner.runCoverage();
+    
+    expect(result).toBeInstanceOf(Promise);
+    
+    const coverageResult = await result;
+    expect(coverageResult).toBeDefined();
+    expect(coverageResult.success).toBe(true);
+    expect(coverageResult.outputPath).toBeDefined();
+  });
+
+  it('should complete within reasonable time', async () => {
+    const runner = new DummyRunner();
+    const startTime = Date.now();
+    
+    await runner.runCoverage();
+    
+    const endTime = Date.now();
+    expect(endTime - startTime).toBeLessThan(100); // Should be near-instant for dummy
+  });
+});

--- a/test/runners/JestRunner.test.ts
+++ b/test/runners/JestRunner.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execa } from 'execa';
+import { JestRunner } from '../../src/runners/JestRunner';
+
+vi.mock('execa');
+
+const mockExeca = vi.mocked(execa);
+
+describe('JestRunner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should implement Runner interface', () => {
+    const runner = new JestRunner();
+    expect(runner).toHaveProperty('runCoverage');
+    expect(typeof runner.runCoverage).toBe('function');
+  });
+
+  it('should execute "jest --coverage" command when runCoverage() is called', async () => {
+    mockExeca.mockResolvedValue({
+      exitCode: 0,
+      stdout: 'Test results output',
+      stderr: '',
+    } as any);
+
+    const runner = new JestRunner();
+    await runner.runCoverage();
+
+    expect(mockExeca).toHaveBeenCalledWith('npx', ['jest', '--coverage', '--coverageDirectory', './coverage'], {
+      stdio: 'pipe',
+    });
+  });
+
+  it('should return success result when jest command succeeds', async () => {
+    mockExeca.mockResolvedValue({
+      exitCode: 0,
+      stdout: 'Test results output',
+      stderr: '',
+    } as any);
+
+    const runner = new JestRunner();
+    const result = await runner.runCoverage();
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.outputPath).toBe('./coverage');
+    expect(result.duration).toBeTypeOf('number');
+  });
+
+  it('should return failure result when jest command fails', async () => {
+    const mockError = {
+      exitCode: 1,
+      stdout: 'Some output',
+      stderr: 'Jest error message',
+    };
+    mockExeca.mockRejectedValue(mockError);
+
+    const runner = new JestRunner();
+    const result = await runner.runCoverage();
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('Jest error message');
+    expect(result.stdout).toBe('Some output');
+  });
+
+  it('should use COVERAGE_OUTPUT_DIR environment variable when set', async () => {
+    const originalEnv = process.env.COVERAGE_OUTPUT_DIR;
+    process.env.COVERAGE_OUTPUT_DIR = '/tmp/custom-coverage';
+
+    mockExeca.mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    } as any);
+
+    const runner = new JestRunner();
+    await runner.runCoverage();
+
+    expect(mockExeca).toHaveBeenCalledWith('npx', ['jest', '--coverage', '--coverageDirectory', '/tmp/custom-coverage'], {
+      stdio: 'pipe',
+    });
+
+    // Restore original environment
+    if (originalEnv !== undefined) {
+      process.env.COVERAGE_OUTPUT_DIR = originalEnv;
+    } else {
+      delete process.env.COVERAGE_OUTPUT_DIR;
+    }
+  });
+});

--- a/test/runners/VitestRunner.test.ts
+++ b/test/runners/VitestRunner.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execa } from 'execa';
+import { VitestRunner } from '../../src/runners/VitestRunner';
+
+vi.mock('execa');
+
+const mockExeca = vi.mocked(execa);
+
+describe('VitestRunner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should implement Runner interface', () => {
+    const runner = new VitestRunner();
+    expect(runner).toHaveProperty('runCoverage');
+    expect(typeof runner.runCoverage).toBe('function');
+  });
+
+  it('should execute "vitest run --coverage" command when runCoverage() is called', async () => {
+    mockExeca.mockResolvedValue({
+      exitCode: 0,
+      stdout: 'Test results output',
+      stderr: '',
+    } as any);
+
+    const runner = new VitestRunner();
+    await runner.runCoverage();
+
+    expect(mockExeca).toHaveBeenCalledWith('npx', ['vitest', 'run', '--coverage', '--coverage.reportsDirectory', './coverage'], {
+      stdio: 'pipe',
+    });
+  });
+
+  it('should return success result when vitest command succeeds', async () => {
+    mockExeca.mockResolvedValue({
+      exitCode: 0,
+      stdout: 'Test results output',
+      stderr: '',
+    } as any);
+
+    const runner = new VitestRunner();
+    const result = await runner.runCoverage();
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.outputPath).toBe('./coverage');
+    expect(result.duration).toBeTypeOf('number');
+  });
+
+  it('should return failure result when vitest command fails', async () => {
+    const mockError = {
+      exitCode: 1,
+      stdout: 'Some output',
+      stderr: 'Vitest error message',
+    };
+    mockExeca.mockRejectedValue(mockError);
+
+    const runner = new VitestRunner();
+    const result = await runner.runCoverage();
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('Vitest error message');
+    expect(result.stdout).toBe('Some output');
+  });
+
+  it('should use COVERAGE_OUTPUT_DIR environment variable when set', async () => {
+    const originalEnv = process.env.COVERAGE_OUTPUT_DIR;
+    process.env.COVERAGE_OUTPUT_DIR = '/tmp/custom-coverage';
+
+    mockExeca.mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    } as any);
+
+    const runner = new VitestRunner();
+    await runner.runCoverage();
+
+    expect(mockExeca).toHaveBeenCalledWith('npx', ['vitest', 'run', '--coverage', '--coverage.reportsDirectory', '/tmp/custom-coverage'], {
+      stdio: 'pipe',
+    });
+
+    // Restore original environment
+    if (originalEnv !== undefined) {
+      process.env.COVERAGE_OUTPUT_DIR = originalEnv;
+    } else {
+      delete process.env.COVERAGE_OUTPUT_DIR;
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "examples"
   ]
 }


### PR DESCRIPTION
## Summary
- Implement complete coverage runner system following TDD principles with Red → Green → Refactor cycles
- Add Runner interface and BaseRunner abstract class with comprehensive CoverageResult type system
- Implement JestRunner and VitestRunner with execa-based command execution and error handling
- Add COVERAGE_OUTPUT_DIR environment variable support for flexible output directory configuration
- Create RunnerFactory pattern for clean dependency injection and runner instantiation

## Key Features
- **Complete TDD Implementation**: Following t-wada practices with 39 passing tests
- **Runner Architecture**: Clean abstraction with BaseRunner providing common functionality
- **CLI Integration**: Full detection → execution → reporting workflow in run command
- **Environment Support**: Configurable output directories via COVERAGE_OUTPUT_DIR
- **Comprehensive Testing**: Unit, integration, and E2E tests with mocked command execution

## Test Coverage
- **Unit Tests**: All runner classes with mocked execa execution
- **Integration Tests**: CLI workflow validation with mock dependencies
- **E2E Tests**: Real sample projects for Jest and Vitest validation
- **Example Projects**: Working Jest and Vitest projects for testing

## TDD Process Followed
1. **Red Phase**: Write failing tests for each runner and CLI integration
2. **Green Phase**: Implement minimal code to make tests pass
3. **Refactor Phase**: Extract common functionality to BaseRunner and RunnerFactory

## Usage Examples
```bash
# Detect and run all test runners
coverage-runner run

# Run with custom package.json
coverage-runner run --path /custom/path/package.json

# Debug mode with detailed output
coverage-runner run --debug
```

## Test Results
- ✅ 39 tests passing
- ✅ Unit tests for DummyRunner, JestRunner, VitestRunner
- ✅ Integration tests for CLI workflow
- ✅ E2E tests with real projects
- ✅ Environment variable configuration working

🤖 Generated with [Claude Code](https://claude.ai/code)